### PR TITLE
implement antiquotation for pattern matching

### DIFF
--- a/lib/pattern.ml
+++ b/lib/pattern.ml
@@ -20,7 +20,7 @@ let expand_anti_quotation ~ppat_loc = function
   | PPat (ppat, _) -> ppat
   | PStr _
   | PSig _
-  | PTyp _ -> Raise.bad_expr_antiquotation_payload ~loc:ppat_loc
+  | PTyp _ -> Raise.bad_pat_antiquotation_payload ~loc:ppat_loc
 
 let rec expand ~loc ~path pat =
   match pat with

--- a/lib/raise.ml
+++ b/lib/raise.ml
@@ -14,3 +14,8 @@ let bad_expr_antiquotation_payload ~loc =
   Location.raise_errorf
     ~loc
     "ppx_yojson: bad antiquotation payload, should be a single expression"
+
+let bad_pat_antiquotation_payload ~loc =
+  Location.raise_errorf
+    ~loc
+    "ppx_yojson: bad antiquotation payload, should be a pattern"

--- a/lib/raise.mli
+++ b/lib/raise.mli
@@ -24,3 +24,8 @@ val too_many_fields_in_record_pattern :
 val bad_expr_antiquotation_payload :
   loc: Ppxlib.Location.t ->
   'a
+
+(** Use this for bad payload in pattern antiquotation [[%y? ...]]. *)
+val bad_pat_antiquotation_payload :
+  loc: Ppxlib.Location.t ->
+  'a

--- a/test/rewriter/errors/dune.inc
+++ b/test/rewriter/errors/dune.inc
@@ -156,6 +156,32 @@
 )
 
 (library
+  (name pat_anti_quotation_payload)
+  (modules pat_anti_quotation_payload)
+  (preprocess (pps ppx_yojson))
+)
+
+(rule
+  (targets pat_anti_quotation_payload.actual)
+  (deps (:pp pp.exe) (:input pat_anti_quotation_payload.ml))
+  (action
+    (setenv "OCAML_ERROR_STYLE" "short"
+      (setenv "OCAML_COLOR" "never"
+        (with-stderr-to
+          %{targets}
+          (bash "./%{pp} -no-color --impl %{input} || true")
+        )
+      )
+    )
+  )
+)
+
+(alias
+  (name runtest)
+  (action (diff pat_anti_quotation_payload.expected pat_anti_quotation_payload.actual))
+)
+
+(library
   (name pat_integer_literal_binary)
   (modules pat_integer_literal_binary)
   (preprocess (pps ppx_yojson))

--- a/test/rewriter/errors/pat_anti_quotation_payload.expected
+++ b/test/rewriter/errors/pat_anti_quotation_payload.expected
@@ -1,0 +1,2 @@
+File "pat_anti_quotation_payload.ml", line 2, characters 14-26:
+Error: ppx_yojson: bad antiquotation payload, should be a pattern

--- a/test/rewriter/errors/pat_anti_quotation_payload.ml
+++ b/test/rewriter/errors/pat_anti_quotation_payload.ml
@@ -1,0 +1,3 @@
+let invalid_anti_quotation_pattern = function
+  | [%yojson? [%y `Int _a]] -> false
+  | _ -> true

--- a/test/rewriter/pp.expected.ml
+++ b/test/rewriter/pp.expected.ml
@@ -89,5 +89,6 @@ let patterns =
     | `Intlit "1" as _int_32 -> ()
     | `Intlit "1" as _native_int -> ()
     | _s as _var -> ()
+    | `Assoc (("a", `Int _i)::[]) as _var -> ()
     | _ as _any -> ())
   [@warning "-11"])

--- a/test/rewriter/test.ml
+++ b/test/rewriter/test.ml
@@ -52,4 +52,5 @@ let patterns = function [@warning "-11"]
   | [%yojson? 1l] as _int_32 -> ()
   | [%yojson? 1n] as _native_int -> ()
   | [%yojson? _s] as _var -> ()
+  | [%yojson? { a = [%y? `Int _i]}] as _var -> ()
   | [%yojson? _] as _any -> ()


### PR DESCRIPTION
Implemented antiquotation for pattern matching which mimics the one in [expression.ml].

Added a test for that showing it's working