### PR TITLE
Make ppx_yojson compatible with ppxlib.0.18.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### Added
+
+- Make ppx_yojson fully compatible with 4.11 (#22, @NathanReb)
+
 ## 1.0.0
 
 ### Additions

--- a/dune-project
+++ b/dune-project
@@ -14,5 +14,5 @@
  (depends
   (ocaml (>= 4.04.2))
   (alcotest :with-test)
-  (ppxlib (and (>= 0.3.0) (< 0.18.0)))
+  (ppxlib (>= 0.18.0))
   (yojson (and :with-test (>= 1.6.0)))))

--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -29,7 +29,7 @@ let rec expand ~loc ~path expr =
   | [%expr None] -> [%expr `Null]
   | [%expr true] -> [%expr `Bool true]
   | [%expr false] -> [%expr `Bool false]
-  | { pexp_desc = Pexp_constant (Pconst_string (s, None)); _ } ->
+  | { pexp_desc = Pexp_constant (Pconst_string (s, _, None)); _ } ->
       expand_string ~loc s
   | { pexp_desc = Pexp_constant (Pconst_integer (s, None)); pexp_loc; _ } ->
       expand_int ~loc ~pexp_loc s

--- a/lib/pattern.ml
+++ b/lib/pattern.ml
@@ -32,7 +32,7 @@ let rec expand ~loc ~path pat =
   | [%pat? None] -> [%pat? `Null]
   | [%pat? true] -> [%pat? `Bool true]
   | [%pat? false] -> [%pat? `Bool false]
-  | { ppat_desc = Ppat_constant (Pconst_string (s, None)); _ } ->
+  | { ppat_desc = Ppat_constant (Pconst_string (s, _, None)); _ } ->
       expand_string ~loc s
   | { ppat_desc = Ppat_constant (Pconst_integer (s, None)); ppat_loc; _ } ->
       expand_int ~loc ~ppat_loc s

--- a/ppx_yojson.opam
+++ b/ppx_yojson.opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "2.1"}
   "ocaml" {>= "4.04.2"}
   "alcotest" {with-test}
-  "ppxlib" {>= "0.3.0" & < "0.18.0"}
+  "ppxlib" {>= "0.18.0"}
   "yojson" {with-test & >= "1.6.0"}
 ]
 build: [


### PR DESCRIPTION
ppxlib.0.18.0 uses the 4.11 AST internally and that changed how string constant were represented.