### PR TITLE
Add an alternative, more generic antiquotation syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Support `%ezjsonm` extension to output Ezjsonm-compatible values.
   (#31, @mefyl)
+- Add generic antiquotation syntax `[%aq ...]` (#<PR_NUMBER>, @NathanReb)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 - Support `%ezjsonm` extension to output Ezjsonm-compatible values.
   (#31, @mefyl)
-- Add generic antiquotation syntax `[%aq ...]` (#<PR_NUMBER>, @NathanReb)
+- Add generic antiquotation syntax `[%aq ...]` (#32, @NathanReb)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -80,19 +80,19 @@ regardless.
 
 #### Anti-quotation
 
-You can escape regular `Yojson` expressions within a payload using `[%y json_expr]`. You can use
+You can escape regular `Yojson` expressions within a payload using `[%aq json_expr]`. You can use
 this to insert variables in the payload. For example:
 
 ```ocaml
 let a = `String "a"
-let json = [%yojson { a = [%y a]; b = "b"}]
+let json = [%yojson { a = [%aq a]; b = "b"}]
 ```
 is rewritten as:
 ```ocaml
 let a = `String "a"
 let json = `Assoc [("a", a); (b, `String "b")]
 ```
-Note that the payload in a `%y` extension should always subtype one of the `Yojson` types.
+Note that the payload in a `%aq` extension should always subtype one of the `Yojson` types.
 
 ### Patterns
 
@@ -147,11 +147,11 @@ let f = function
 #### Anti-quotation
 
 You can also escape regular `Yojson` patterns in `ppx_yojson` pattern extensions' payload
-using `[%y? json_pat]`. You can use it to further deconstruct a `Yojson` value. For example:
+using `[%aq? json_pat]`. You can use it to further deconstruct a `Yojson` value. For example:
 
 ```ocaml
 let f = function
-  | [%yojson? {a = [%y? `Int i]} -> i + 1
+  | [%yojson? {a = [%aq? `Int i]} -> i + 1
 ```
 
 is expanded into:

--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -114,7 +114,8 @@ module Make (Expander : EXPANDER) = struct
         Expander.expand_list ~loc (expand_list ~loc ~path expr)
     | { pexp_desc = Pexp_record (l, None); _ } ->
         Expander.expand_record ~loc (expand_record ~path l)
-    | { pexp_desc = Pexp_extension ({ txt = "y"; _ }, p); pexp_loc; _ } ->
+    | { pexp_desc = Pexp_extension ({ txt = "y" | "aq"; _ }, p); pexp_loc; _ }
+      ->
         expand_anti_quotation ~pexp_loc p
     | _ -> Raise.unsupported_payload ~loc:expr.pexp_loc
 

--- a/lib/pattern.ml
+++ b/lib/pattern.ml
@@ -44,7 +44,7 @@ let rec expand ~loc ~path pat =
   | { ppat_desc = Ppat_constant (Pconst_float (s, None)); _ } ->
       expand_float ~loc s
   | { ppat_desc = Ppat_var v; _ } -> expand_var ~loc v
-  | { ppat_desc = Ppat_extension ({ txt = "y"; _ }, p); ppat_loc; _ } ->
+  | { ppat_desc = Ppat_extension ({ txt = "y" | "aq"; _ }, p); ppat_loc; _ } ->
       expand_anti_quotation ~ppat_loc p
   | [%pat? [%p? left] | [%p? right]] ->
       [%pat? [%p expand ~loc ~path left] | [%p expand ~loc ~path right]]

--- a/test/rewriter/ezjsonm.expected.ml
+++ b/test/rewriter/ezjsonm.expected.ml
@@ -18,4 +18,5 @@ let complex =
       (`A
          [`O [("name", (`String "Kurt Cobain")); ("age", (`Float 27))];
          `O [("name", (`String "Jesus Christ")); ("age", (`Float 33))]]))]
+let legacy_anti_quotation = `O [("a", (`String "a")); ("b", (`Float 1))]
 let anti_quotation = `O [("a", (`String "a")); ("b", (`Float 1))]

--- a/test/rewriter/ezjsonm.ml
+++ b/test/rewriter/ezjsonm.ml
@@ -21,4 +21,5 @@ let complex =
         ]
     }
   ]
-let anti_quotation = [%ezjsonm {a = [%y `String "a"]; b = 1}]
+let legacy_anti_quotation = [%ezjsonm {a = [%y `String "a"]; b = 1}]
+let anti_quotation = [%ezjsonm {a = [%aq `String "a"]; b = 1}]

--- a/test/rewriter/ezjsonm.mli
+++ b/test/rewriter/ezjsonm.mli
@@ -11,4 +11,5 @@ val array : json
 val mixed_array : json
 val record : json
 val complex : json
+val legacy_anti_quotation : json
 val anti_quotation : json

--- a/test/rewriter/yojson.expected.ml
+++ b/test/rewriter/yojson.expected.ml
@@ -18,6 +18,7 @@ let complex =
       (`List
          [`Assoc [("name", (`String "Kurt Cobain")); ("age", (`Int 27))];
          `Assoc [("name", (`String "Jesus Christ")); ("age", (`Int 33))]]))]
+let legacy_anti_quotation = `Assoc [("a", (`String "a")); ("b", (`Int 1))]
 let anti_quotation = `Assoc [("a", (`String "a")); ("b", (`Int 1))]
 let int_64 = `Intlit "1"
 let int_32 = `Intlit "1"
@@ -89,6 +90,7 @@ let patterns =
     | `Intlit "1" as _int_32 -> ()
     | `Intlit "1" as _native_int -> ()
     | _s as _var -> ()
+    | `Assoc (("a", `Int _i)::[]) as _legacy_var -> ()
     | `Assoc (("a", `Int _i)::[]) as _var -> ()
     | _ as _any -> ())
   [@warning "-11"])

--- a/test/rewriter/yojson.ml
+++ b/test/rewriter/yojson.ml
@@ -20,7 +20,8 @@ let complex =
         ]
     }
   ]
-let anti_quotation = [%yojson {a = [%y `String "a"]; b = 1}]
+let legacy_anti_quotation = [%yojson {a = [%y `String "a"]; b = 1}]
+let anti_quotation = [%yojson {a = [%aq `String "a"]; b = 1}]
 let int_64 = [%yojson 1L]
 let int_32 = [%yojson 1l]
 let native_int = [%yojson 1n]
@@ -52,5 +53,6 @@ let patterns = function [@warning "-11"]
   | [%yojson? 1l] as _int_32 -> ()
   | [%yojson? 1n] as _native_int -> ()
   | [%yojson? _s] as _var -> ()
-  | [%yojson? { a = [%y? `Int _i]}] as _var -> ()
+  | [%yojson? { a = [%y? `Int _i]}] as _legacy_var -> ()
+  | [%yojson? { a = [%aq? `Int _i]}] as _var -> ()
   | [%yojson? _] as _any -> ()

--- a/test/rewriter/yojson.mli
+++ b/test/rewriter/yojson.mli
@@ -12,6 +12,7 @@ val array : json
 val mixed_array : json
 val record : json
 val complex : json
+val legacy_anti_quotation : json
 val anti_quotation : json
 val int_64 : json
 val int_32 : json


### PR DESCRIPTION
The old`[%y ...]` syntax was intended as short for yojson. It does not make as much sense now that we support ezjsonm.