### PR TITLE
Drop old stdlib compat layer

### DIFF
--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -51,7 +51,7 @@ module Ezjsonm_expander : EXPANDER = struct
   let expand_intlit ~loc _ = Raise.unsupported_payload ~loc
 
   let expand_int ~loc ~pexp_loc s =
-    match Ocaml_compat.int_of_string_opt s with
+    match int_of_string_opt s with
     | Some i ->
         [%expr `Float [%e Ast_builder.Default.efloat ~loc (string_of_int i)]]
     | _ -> Raise.unsupported_payload ~loc:pexp_loc
@@ -70,7 +70,7 @@ module Yojson_expander : EXPANDER = struct
     [%expr `Intlit [%e Ast_builder.Default.estring ~loc s]]
 
   let expand_int ~loc ~pexp_loc s =
-    match Ocaml_compat.int_of_string_opt s with
+    match int_of_string_opt s with
     | Some i -> [%expr `Int [%e Ast_builder.Default.eint ~loc i]]
     | None when Integer_const.is_binary s ->
         Raise.unsupported_payload ~loc:pexp_loc

--- a/lib/ocaml_compat.ml
+++ b/lib/ocaml_compat.ml
@@ -1,1 +1,0 @@
-let int_of_string_opt s = try Some (int_of_string s) with Failure _ -> None

--- a/lib/ocaml_compat.mli
+++ b/lib/ocaml_compat.mli
@@ -1,3 +1,0 @@
-(** Redefined standard library functions for compatibility with older Ocaml versions *)
-
-val int_of_string_opt : string -> int option

--- a/lib/pattern.ml
+++ b/lib/pattern.ml
@@ -7,7 +7,7 @@ let expand_intlit ~loc s =
   [%pat? `Intlit [%p Ast_builder.Default.pstring ~loc s]]
 
 let expand_int ~loc ~ppat_loc s =
-  match Ocaml_compat.int_of_string_opt s with
+  match int_of_string_opt s with
   | Some i -> [%pat? `Int [%p Ast_builder.Default.pint ~loc i]]
   | None when Integer_const.is_binary s ->
       Raise.unsupported_payload ~loc:ppat_loc


### PR DESCRIPTION
This is not required anymore now that the minimum OCaml version we support is 4.08