### PR TITLE
Removed the Raise commands and embedded error_extensionf for unsupported payload error

### DIFF
--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -48,7 +48,8 @@ end
 module Ezjsonm_expander : EXPANDER = struct
   include Common
 
-  let expand_intlit ~loc _ = Raise.unsupported_payload ~loc
+  let expand_intlit ~loc _ = Ast_builder.Default.pexp_extension ~loc
+                    @@ Location.error_extensionf ~loc "ppx_yojson: unsupported payload"
 
   let expand_int ~loc ~pexp_loc s =
     match int_of_string_opt s with

--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -121,7 +121,8 @@ module Make (Expander : EXPANDER) = struct
     | { pexp_desc = Pexp_extension ({ txt = "y" | "aq"; _ }, p); pexp_loc; _ }
       ->
         expand_anti_quotation ~pexp_loc p
-    | _ -> Raise.unsupported_payload ~loc:expr.pexp_loc
+    | _ -> Ast_builder.Default.pexp_extension ~loc
+                    @@ Location.error_extensionf ~loc:expr.pexp_loc "ppx_yojson: unsupported payload"
 
   and expand_list ~loc ~path = function
     | [%expr []] -> []

--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -54,7 +54,8 @@ module Ezjsonm_expander : EXPANDER = struct
     match int_of_string_opt s with
     | Some i ->
         [%expr `Float [%e Ast_builder.Default.efloat ~loc (string_of_int i)]]
-    | _ -> Raise.unsupported_payload ~loc:pexp_loc
+    | _ -> Ast_builder.Default.pexp_extension ~loc
+                    @@ Location.error_extensionf ~loc:pexp_loc "ppx_yojson: unsupported payload"
 
   let expand_list ~loc exprs =
     expand_list ~loc (fun e -> [%expr `A [%e e]]) exprs
@@ -73,11 +74,14 @@ module Yojson_expander : EXPANDER = struct
     match int_of_string_opt s with
     | Some i -> [%expr `Int [%e Ast_builder.Default.eint ~loc i]]
     | None when Integer_const.is_binary s ->
-        Raise.unsupported_payload ~loc:pexp_loc
+        Ast_builder.Default.pexp_extension ~loc
+                    @@ Location.error_extensionf ~loc:pexp_loc "ppx_yojson: unsupported payload"
     | None when Integer_const.is_octal s ->
-        Raise.unsupported_payload ~loc:pexp_loc
+        Ast_builder.Default.pexp_extension ~loc
+                    @@ Location.error_extensionf ~loc:pexp_loc "ppx_yojson: unsupported payload"
     | None when Integer_const.is_hexadecimal s ->
-        Raise.unsupported_payload ~loc:pexp_loc
+        Ast_builder.Default.pexp_extension ~loc
+                    @@ Location.error_extensionf ~loc:pexp_loc "ppx_yojson: unsupported payload"
     | None -> expand_intlit ~loc s
 
   let expand_list ~loc exprs =

--- a/lib/pattern.ml
+++ b/lib/pattern.ml
@@ -10,11 +10,14 @@ let expand_int ~loc ~ppat_loc s =
   match int_of_string_opt s with
   | Some i -> [%pat? `Int [%p Ast_builder.Default.pint ~loc i]]
   | None when Integer_const.is_binary s ->
-      Raise.unsupported_payload ~loc:ppat_loc
+      Ast_builder.Default.ppat_extension ~loc
+                    @@ Location.error_extensionf ~loc:ppat_loc "ppx_yojson: unsupported payload"
   | None when Integer_const.is_octal s ->
-      Raise.unsupported_payload ~loc:ppat_loc
+      Ast_builder.Default.ppat_extension ~loc
+                    @@ Location.error_extensionf ~loc:ppat_loc "ppx_yojson: unsupported payload"
   | None when Integer_const.is_hexadecimal s ->
-      Raise.unsupported_payload ~loc:ppat_loc
+      Ast_builder.Default.ppat_extension ~loc
+                    @@ Location.error_extensionf ~loc:ppat_loc "ppx_yojson: unsupported payload"
   | None -> expand_intlit ~loc s
 
 let expand_float ~loc s = [%pat? `Float [%p Ast_builder.Default.pfloat ~loc s]]
@@ -75,7 +78,9 @@ and expand_record ~loc ~ppat_loc ~path l =
     [%pat? `Assoc [%p Ast_builder.Default.plist ~loc pat_list]]
   in
   if List.length l > 4 then
-    Raise.too_many_fields_in_record_pattern ~loc:ppat_loc
+    Ast_builder.Default.ppat_extension ~loc
+                    @@ Location.error_extensionf ~loc:ppat_loc "ppx_yojson: record patterns with more than 4 fields aren't supported. \
+     Consider using ppx_deriving_yojson to handle more complex json objects."
   else
     let pat_list = List.map expand_one l in
     let permutations = Utils.permutations pat_list in


### PR DESCRIPTION
Hey @ayc9 & @pitag-ha
I have removed the `Raise` commands and embedded `error_extensionf` for all errors (except 3-4 which are creating issues) in this PR.