### PR TITLE
Strip leading underscores in object field names.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Ignore leading underscores in object field names.
+
 ### Deprecated
 
 ### Fixed

--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -33,9 +33,7 @@ module Common = struct
   let expand_record ~loc wrap fields =
     let fields =
       let f (name, value) =
-        [%expr
-          [%e Ast_builder.Default.estring ~loc @@ Utils.rewrite_field_name name],
-            [%e value]]
+        [%expr [%e Ast_builder.Default.estring ~loc name], [%e value]]
       in
       List.map f fields
     in
@@ -125,11 +123,22 @@ module Make (Expander : EXPANDER) = struct
     | _ -> assert false
 
   and expand_record ~path l =
-    let field = function
-      | { txt = Lident s; _ } -> s
-      | { txt = _; loc } -> Raise.unsupported_record_field ~loc
+    let expand_one (f, e) =
+      let field =
+        match
+          ( List.find_opt
+              (fun attr -> String.equal attr.attr_name.txt "as")
+              e.pexp_attributes,
+            f )
+        with
+        | Some { attr_payload; attr_loc = loc; _ }, _ ->
+            Ast_pattern.(parse (single_expr_payload (estring __)))
+              loc attr_payload (fun e -> e)
+        | None, { txt = Lident s; _ } -> Utils.rewrite_field_name s
+        | None, { txt = _; loc } -> Raise.unsupported_record_field ~loc
+      in
+      (field, expand ~loc:e.pexp_loc ~path e)
     in
-    let expand_one (f, e) = (field f, expand ~loc:e.pexp_loc ~path e) in
     List.map expand_one l
 end
 

--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -1,5 +1,8 @@
 open Ppxlib
 
+let rewrite_field_name name =
+  if name.[0] = '_' then String.(sub name 1 (length name - 1)) else name
+
 module type EXPANDER = sig
   val expand_bool : loc:location -> bool -> expression
   val expand_float : loc:location -> string -> expression
@@ -9,7 +12,7 @@ module type EXPANDER = sig
   val expand_none : loc:location -> unit -> expression
 
   val expand_record : loc:location -> (string * expression) list -> expression
-  (** Expands a list of field names and associated expanded expressions into 
+  (** Expands a list of field names and associated expanded expressions into
       the corresponding JSON object encoding. *)
 
   val expand_string : loc:location -> string -> expression
@@ -33,7 +36,9 @@ module Common = struct
   let expand_record ~loc wrap fields =
     let fields =
       let f (name, value) =
-        [%expr [%e Ast_builder.Default.estring ~loc name], [%e value]]
+        [%expr
+          [%e Ast_builder.Default.estring ~loc @@ rewrite_field_name name],
+            [%e value]]
       in
       List.map f fields
     in

--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -1,8 +1,5 @@
 open Ppxlib
 
-let rewrite_field_name name =
-  if name.[0] = '_' then String.(sub name 1 (length name - 1)) else name
-
 module type EXPANDER = sig
   val expand_bool : loc:location -> bool -> expression
   val expand_float : loc:location -> string -> expression
@@ -37,7 +34,7 @@ module Common = struct
     let fields =
       let f (name, value) =
         [%expr
-          [%e Ast_builder.Default.estring ~loc @@ rewrite_field_name name],
+          [%e Ast_builder.Default.estring ~loc @@ Utils.rewrite_field_name name],
             [%e value]]
       in
       List.map f fields

--- a/lib/pattern.ml
+++ b/lib/pattern.ml
@@ -65,12 +65,23 @@ and expand_list ~loc ~path = function
   | _ -> assert false
 
 and expand_record ~loc ~ppat_loc ~path l =
-  let field = function
-    | { txt = Lident s; _ } ->
-        Ast_builder.Default.pstring ~loc @@ Utils.rewrite_field_name s
-    | { txt = _; loc } -> Raise.unsupported_record_field ~loc
+  let expand_one (f, p) =
+    let field =
+      match
+        ( List.find_opt
+            (fun attr -> String.equal attr.attr_name.txt "as")
+            p.ppat_attributes,
+          f )
+      with
+      | Some { attr_payload; attr_loc = loc; _ }, _ ->
+          Ast_pattern.(parse (single_expr_payload (estring __)))
+            loc attr_payload (fun e -> e)
+      | None, { txt = Lident s; _ } -> Utils.rewrite_field_name s
+      | None, { txt = _; loc } -> Raise.unsupported_record_field ~loc
+    in
+    [%pat?
+      [%p Ast_builder.Default.pstring ~loc field], [%p expand ~loc ~path p]]
   in
-  let expand_one (f, p) = [%pat? [%p field f], [%p expand ~loc ~path p]] in
   let assoc_pattern pat_list =
     [%pat? `Assoc [%p Ast_builder.Default.plist ~loc pat_list]]
   in

--- a/lib/pattern.ml
+++ b/lib/pattern.ml
@@ -66,7 +66,8 @@ and expand_list ~loc ~path = function
 
 and expand_record ~loc ~ppat_loc ~path l =
   let field = function
-    | { txt = Lident s; _ } -> Ast_builder.Default.pstring ~loc s
+    | { txt = Lident s; _ } ->
+        Ast_builder.Default.pstring ~loc @@ Utils.rewrite_field_name s
     | { txt = _; loc } -> Raise.unsupported_record_field ~loc
   in
   let expand_one (f, p) = [%pat? [%p field f], [%p expand ~loc ~path p]] in

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -16,3 +16,6 @@ let rec permutations = function
           List.map (List.cons elm) (permutations @@ remove ~idx l))
         l
       |> List.flatten
+
+let rewrite_field_name name =
+  if name.[0] = '_' then String.(sub name 1 (length name - 1)) else name

--- a/lib/utils.mli
+++ b/lib/utils.mli
@@ -7,3 +7,8 @@ val remove : idx:int -> 'a list -> 'a list
 
 val permutations : 'a list -> 'a list list
 (** Return all the permutations of the given list *)
+
+val rewrite_field_name : string -> string
+(** Map OCaml record field name to the corresponding JSON field name.
+
+    Ie. trim one leading undescore. *)

--- a/test/rewriter/ezjsonm.expected.ml
+++ b/test/rewriter/ezjsonm.expected.ml
@@ -20,3 +20,8 @@ let complex =
          `O [("name", (`String "Jesus Christ")); ("age", (`Float 33))]]))]
 let legacy_anti_quotation = `O [("a", (`String "a")); ("b", (`Float 1))]
 let anti_quotation = `O [("a", (`String "a")); ("b", (`Float 1))]
+let field_renaming =
+  `O
+    [("object", (`String "object"));
+    ("Ctor", (`String "ctor"));
+    ("_double", (`String "_double"))]

--- a/test/rewriter/ezjsonm.expected.ml
+++ b/test/rewriter/ezjsonm.expected.ml
@@ -24,4 +24,5 @@ let field_renaming =
   `O
     [("object", (`String "object"));
     ("Ctor", (`String "ctor"));
-    ("_double", (`String "_double"))]
+    ("_double", (`String "_double"));
+    ("@type", (`String "@type"))]

--- a/test/rewriter/ezjsonm.ml
+++ b/test/rewriter/ezjsonm.ml
@@ -23,3 +23,4 @@ let complex =
   ]
 let legacy_anti_quotation = [%ezjsonm {a = [%y `String "a"]; b = 1}]
 let anti_quotation = [%ezjsonm {a = [%aq `String "a"]; b = 1}]
+let field_renaming = [%ezjsonm {_object = "object"; _Ctor = "ctor"; __double = "_double"}]

--- a/test/rewriter/ezjsonm.ml
+++ b/test/rewriter/ezjsonm.ml
@@ -23,4 +23,4 @@ let complex =
   ]
 let legacy_anti_quotation = [%ezjsonm {a = [%y `String "a"]; b = 1}]
 let anti_quotation = [%ezjsonm {a = [%aq `String "a"]; b = 1}]
-let field_renaming = [%ezjsonm {_object = "object"; _Ctor = "ctor"; __double = "_double"}]
+let field_renaming = [%ezjsonm {_object = "object"; _Ctor = "ctor"; __double = "_double"; type_ = "@type" [@as "@type"]}]

--- a/test/rewriter/yojson.expected.ml
+++ b/test/rewriter/yojson.expected.ml
@@ -94,3 +94,8 @@ let patterns =
     | `Assoc (("a", `Int _i)::[]) as _var -> ()
     | _ as _any -> ())
   [@warning "-11"])
+let field_renaming =
+  `Assoc
+    [("object", (`String "object"));
+    ("Ctor", (`String "ctor"));
+    ("_double", (`String "_double"))]

--- a/test/rewriter/yojson.expected.ml
+++ b/test/rewriter/yojson.expected.ml
@@ -93,12 +93,10 @@ let patterns =
     | `Assoc (("a", `Int _i)::[]) as _legacy_var -> ()
     | `Assoc (("a", `Int _i)::[]) as _var -> ()
     | _ as _any -> ()
-    | `Assoc (("object", _)::("Ctor", _)::("_double", _)::[])
-      | `Assoc (("object", _)::("_double", _)::("Ctor", _)::[])
-      | `Assoc (("Ctor", _)::("object", _)::("_double", _)::[])
-      | `Assoc (("Ctor", _)::("_double", _)::("object", _)::[])
-      | `Assoc (("_double", _)::("object", _)::("Ctor", _)::[])
-      | `Assoc (("_double", _)::("Ctor", _)::("object", _)::[]) -> ())
+    | `Assoc (("object", _)::("Ctor", _)::[])
+      | `Assoc (("Ctor", _)::("object", _)::[]) -> ()
+    | `Assoc (("_double", _)::("@type", _)::[])
+      | `Assoc (("@type", _)::("_double", _)::[]) -> ())
   [@warning "-11"])
 let field_renaming =
   `Assoc

--- a/test/rewriter/yojson.expected.ml
+++ b/test/rewriter/yojson.expected.ml
@@ -92,7 +92,13 @@ let patterns =
     | _s as _var -> ()
     | `Assoc (("a", `Int _i)::[]) as _legacy_var -> ()
     | `Assoc (("a", `Int _i)::[]) as _var -> ()
-    | _ as _any -> ())
+    | _ as _any -> ()
+    | `Assoc (("object", _)::("Ctor", _)::("_double", _)::[])
+      | `Assoc (("object", _)::("_double", _)::("Ctor", _)::[])
+      | `Assoc (("Ctor", _)::("object", _)::("_double", _)::[])
+      | `Assoc (("Ctor", _)::("_double", _)::("object", _)::[])
+      | `Assoc (("_double", _)::("object", _)::("Ctor", _)::[])
+      | `Assoc (("_double", _)::("Ctor", _)::("object", _)::[]) -> ())
   [@warning "-11"])
 let field_renaming =
   `Assoc

--- a/test/rewriter/yojson.ml
+++ b/test/rewriter/yojson.ml
@@ -56,3 +56,5 @@ let patterns = function [@warning "-11"]
   | [%yojson? { a = [%y? `Int _i]}] as _legacy_var -> ()
   | [%yojson? { a = [%aq? `Int _i]}] as _var -> ()
   | [%yojson? _] as _any -> ()
+
+let field_renaming   = [%yojson {_object = "object"; _Ctor = "ctor"; __double = "_double"}]

--- a/test/rewriter/yojson.ml
+++ b/test/rewriter/yojson.ml
@@ -56,6 +56,7 @@ let patterns = function [@warning "-11"]
   | [%yojson? { a = [%y? `Int _i]}] as _legacy_var -> ()
   | [%yojson? { a = [%aq? `Int _i]}] as _var -> ()
   | [%yojson? _] as _any -> ()
-  | [%yojson? {_object = _; _Ctor = _; __double = _} ] -> ()
+  | [%yojson? {_object = _; _Ctor = _} ] -> ()
+  | [%yojson? {__double = _; type_ = _ [@as "@type"]} ] -> ()
 
 let field_renaming   = [%yojson {_object = "object"; _Ctor = "ctor"; __double = "_double"}]

--- a/test/rewriter/yojson.ml
+++ b/test/rewriter/yojson.ml
@@ -56,5 +56,6 @@ let patterns = function [@warning "-11"]
   | [%yojson? { a = [%y? `Int _i]}] as _legacy_var -> ()
   | [%yojson? { a = [%aq? `Int _i]}] as _var -> ()
   | [%yojson? _] as _any -> ()
+  | [%yojson? {_object = _; _Ctor = _; __double = _} ] -> ()
 
 let field_renaming   = [%yojson {_object = "object"; _Ctor = "ctor"; __double = "_double"}]

--- a/test/rewriter/yojson.mli
+++ b/test/rewriter/yojson.mli
@@ -17,5 +17,5 @@ val anti_quotation : json
 val int_64 : json
 val int_32 : json
 val native_int : json
-
 val patterns : json -> unit
+val field_renaming : json


### PR DESCRIPTION
This enable to create objects with keys that are OCaml keywords or capitalized, since they would not be valid syntax, eg:

```ocaml
[%yojson {_object = "object"; _Ctor = "ctor"}]
```
